### PR TITLE
fixed the issue about compilation. CPU_SET needs a pointer parameter

### DIFF
--- a/src/Multicore.h
+++ b/src/Multicore.h
@@ -36,7 +36,7 @@ inline void PinThread(const int threadId) {
 #elif __linux__
 	cpu_set_t mask;
 	CPU_ZERO(&mask);
-	CPU_SET(threadId, mask);
+	CPU_SET(threadId, &mask);
 	sched_setaffinity(0, sizeof(mask), &mask);
 #elif __APPLE__
 #endif


### PR DESCRIPTION
I am working on Fedora. My gcc version is "gcc version 5.3.1 20160406 (Red Hat 5.3.1-6) (GCC)"
There is a compiling error.

```
./src/Multicore.h:39:2: error: base operand of ‘->’ has non-pointer type ‘cpu_set_t’
  CPU_SET(threadId, mask);
```
